### PR TITLE
Fixed the error Can't instantiate abstract class DatasetV1 with abstract methods _as_variant_tensor, _inputs

### DIFF
--- a/clinical_concept_extraction/pipeline.py
+++ b/clinical_concept_extraction/pipeline.py
@@ -39,7 +39,7 @@ def get_annotation(all_sentences, batch_size=2):
 
     tf.reset_default_graph()
     with tf.Graph().as_default():
-        dataset = tf.data.Dataset().from_generator(
+        dataset = tf.data.Dataset.from_generator(
             build_generator(x, l),
             (tf.float32, tf.int64),
             (tf.TensorShape([None, 1024, 3]), tf.TensorShape([]))


### PR DESCRIPTION
For tensorflow 1.14.0 in Goolge colab, getting this error `Can't instantiate abstract class DatasetV1 with abstract methods _as_variant_tensor, _inputs`. 
The proposed fix is removing the `()` 

For reference https://github.com/titu1994/neural-image-assessment/issues/51